### PR TITLE
Make it so accidentally tapping the scroll wheel sideways doesn't send you to Narnia

### DIFF
--- a/source/pond.js
+++ b/source/pond.js
@@ -240,6 +240,9 @@ const findFreeEntityIds = () => {
 const onMouseWheel = (e) => {
   e.preventDefault();
   let { deltaY } = e;
+  if (!deltaY) {
+    return;
+  }
   deltaY = deltaY / Math.abs(deltaY);
 
   if (e.altKey) {


### PR DESCRIPTION
Don't calculate zoom if the mouse wheel event has zero delta (wheel event was probably horizontal).

Because `0 / abs(0) = NaN`, and that's not good for math.